### PR TITLE
Additions to the mq-docker image

### DIFF
--- a/8.0.0/Dockerfile
+++ b/8.0.0/Dockerfile
@@ -35,6 +35,9 @@ COPY *.mqsc /etc/mqm/
 # Make sure the MQ environment is available for "docker exec" under non-interactive Bash
 ENV BASH_ENV=/usr/local/bin/mq-env.sh
 
+# Support the latest functional cmdlevel by default
+ENV MQ_QMGR_CMDLEVEL=801
+
 RUN chmod +x /usr/local/bin/*.sh
 
 EXPOSE 1414

--- a/8.0.0/Dockerfile
+++ b/8.0.0/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER Arthur Barr <arthur.barr@uk.ibm.com>
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
 	MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev80_linux_x86-64.tar.gz  && \
-	MQ_PACKAGES="MQSeriesRuntime-*.rpm MQSeriesServer-*.rpm MQSeriesMsg*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm" && \
+	MQ_PACKAGES="MQSeriesRuntime-*.rpm MQSeriesServer-*.rpm MQSeriesMsg*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm" && \
 	echo "mq:8.0" > /etc/debian_chroot && \
 	apt-get update -y && \
 	apt-get install -y curl tar bash rpm bc && \

--- a/8.0.0/mq.sh
+++ b/8.0.0/mq.sh
@@ -31,6 +31,7 @@ config()
 		amqmfsck /var/mqm
 		echo "----------------------------------------"
 		crtmqm -q ${MQ_QMGR_NAME} || true
+		strmqm -e CMDLEVEL=${MQ_QMGR_CMDLEVEL} || true
 		echo "----------------------------------------"
 	fi
 	strmqm ${MQ_QMGR_NAME}

--- a/8.0.0/mq.sh
+++ b/8.0.0/mq.sh
@@ -49,23 +49,29 @@ config()
 
 state()
 {
-   dspmq -n | grep ${MQ_QMGR_NAME} | cut -f3 -d"("
+	dspmq -n -m ${MQ_QMGR_NAME} | awk -F '[()]' '{ print $4 }'
 }
 
 monitor()
 {
 	# Loop until "dspmq" says the queue manager is running
-	until [ "`state`" == "RUNNING)" ]; do
+	until [ "`state`" == "RUNNING" ]; do
 		sleep 1
 	done
 	dspmq
 
 	# Loop until "dspmq" says the queue manager is not running any more
-	until [ "`state`" != "RUNNING)" ]; do
+	until [ "`state`" != "RUNNING" ]; do
 		sleep 5
 	done
 
-	until [[ "`state`" =~ ".*(ENDED.*" ]]; do
+	# Wait until queue manager has ended before exiting
+	while true; do
+		STATE=`state`
+		case "$STATE" in
+			ENDED*) break;;
+			*) ;;
+		esac
 		sleep 1
 	done
 	dspmq


### PR DESCRIPTION
- [x] add MQSeriesJava to the default set of installed packages  
- [x] use latest CMDLEVEL (currently 801) by default  
- [x] fix a weird bug in the monitor() script that was causing containers never to shutdown for me  