### PR TITLE
rpms converted to debs before installation

### DIFF
--- a/7.5.0/Dockerfile
+++ b/7.5.0/Dockerfile
@@ -10,10 +10,10 @@ FROM ubuntu:14.04
 MAINTAINER Arthur Barr <arthur.barr@uk.ibm.com>
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
-	MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev80_linux_x86-64.tar.gz  && \
+	MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev75_linux_x86-64.tar.gz  && \
 	MQ_PACKAGES="MQSeriesRuntime-*.rpm MQSeriesServer-*.rpm MQSeriesMsg*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm" && \
 	DEB_MQ_PACKAGES="mqseriesruntime*deb mqseriesserver*deb mqseriesmsg*deb mqseriesjava*deb mqseriesgskit*deb" && \
-	echo "mq:8.0" > /etc/debian_chroot && \
+	echo "mq:7.5" > /etc/debian_chroot && \
 	apt-get update -y && \
 	apt-get install -y curl tar bash rpm bc alien && \
 	mkdir -p /tmp/mq && \
@@ -41,7 +41,7 @@ COPY *.mqsc /etc/mqm/
 ENV BASH_ENV=/usr/local/bin/mq-env.sh
 
 # Support the latest functional cmdlevel by default
-ENV MQ_QMGR_CMDLEVEL=801
+ENV MQ_QMGR_CMDLEVEL=750
 
 RUN chmod +x /usr/local/bin/*.sh
 

--- a/7.5.0/listener.mqsc
+++ b/7.5.0/listener.mqsc
@@ -1,0 +1,10 @@
+* © Copyright IBM Corporation 2015.
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+
+* Enable and start a TCP/IP listener on port 1414
+ALTER LISTENER('SYSTEM.DEFAULT.LISTENER.TCP') TRPTYPE(TCP) PORT(1414) CONTROL(QMGR)
+START LISTENER('SYSTEM.DEFAULT.LISTENER.TCP')

--- a/7.5.0/mq-env.sh
+++ b/7.5.0/mq-env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# -*- mode: sh -*-
+# © Copyright IBM Corporation 2015.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# Only run setmqenv if we already have a populated /var/mqm
+# This allows us to point BASH_ENV at this file, even if mq.sh hasn't yet populated /var/mqm
+if [ "$(ls -A /var/mqm)" ]; then
+	source /opt/mqm/bin/setmqenv -s
+fi

--- a/7.5.0/mq-license-check.sh
+++ b/7.5.0/mq-license-check.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# -*- mode: sh -*-
+# © Copyright IBM Corporation 2015.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+
+if [ "$LICENSE" = "accept" ]; then
+	exit 0
+elif [ "$LICENSE" = "view" ]; then
+	case "$LANG" in
+		zh_TW*) LICENSE_FILE=Chinese_TW.txt ;;
+		zh*) LICENSE_FILE=Chinese.txt ;;
+		cs*) LICENSE_FILE=Czech.txt ;;
+		en*) LICENSE_FILE=English.txt ;;
+		fr*) LICENSE_FILE=French.txt ;;
+		de*) LICENSE_FILE=German.txt ;;
+		el*) LICENSE_FILE=Greek.txt ;;
+		id*) LICENSE_FILE=Indonesian.txt ;;
+		it*) LICENSE_FILE=Italian.txt ;;
+		ja*) LICENSE_FILE=Japanese.txt ;;
+		ko*) LICENSE_FILE=Korean.txt ;;
+		lt*) LICENSE_FILE=Lithuanian.txt ;;
+		pl*) LICENSE_FILE=Polish.txt ;;
+		pt*) LICENSE_FILE=Portuguese.txt ;;
+		ru*) LICENSE_FILE=Russian.txt ;;
+		sl*) LICENSE_FILE=Slovenian.txt ;;
+		es*) LICENSE_FILE=Spanish.txt ;;
+		tr*) LICENSE_FILE=Turkish.txt ;;
+		*) LICENSE_FILE=English.txt ;;
+	esac
+	cat /opt/mqm/licenses/$LICENSE_FILE
+	exit 1
+else
+	echo -e "Set environment variable LICENSE=accept to indicate acceptance of license terms and conditions.\n\nLicense agreements and information can be viewed by running this image with the environment variable LICENSE=view.  You can also set the LANG environment variable to view the license in a different language."
+	exit 1
+fi

--- a/7.5.0/mq.sh
+++ b/7.5.0/mq.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# -*- mode: sh -*-
+# © Copyright IBM Corporation 2015.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+
+set -e
+
+stop()
+{
+	endmqm $MQ_QMGR_NAME
+}
+
+config()
+{
+	: ${MQ_QMGR_NAME?"ERROR: You need to set the MQ_QMGR_NAME environment variable"}
+	source /opt/mqm/bin/setmqenv -s
+	echo "----------------------------------------"
+	dspmqver
+	echo "----------------------------------------"
+	mqconfig || (echo -e "\nERROR: mqconfig returned a non-zero return code" 1>&2 ; exit 1)
+	echo "----------------------------------------"
+
+	QMGR_EXISTS=`dspmq | grep ${MQ_QMGR_NAME} > /dev/null ; echo $?`
+	if [ ${QMGR_EXISTS} -ne 0 ]; then
+		echo "Checking filesystem..."
+		amqmfsck /var/mqm
+		echo "----------------------------------------"
+		crtmqm -q ${MQ_QMGR_NAME} || true
+		strmqm -e CMDLEVEL=${MQ_QMGR_CMDLEVEL} || true
+		echo "----------------------------------------"
+	fi
+	strmqm ${MQ_QMGR_NAME}
+	if [ ${QMGR_EXISTS} -ne 0 ]; then
+		echo "----------------------------------------"
+		if [ -f /etc/mqm/listener.mqsc ]; then
+			runmqsc ${MQ_QMGR_NAME} < /etc/mqm/listener.mqsc
+		fi
+		if [ -f /etc/mqm/config.mqsc ]; then
+			runmqsc ${MQ_QMGR_NAME} < /etc/mqm/config.mqsc
+		fi
+	fi
+	echo "----------------------------------------"
+}
+
+state()
+{
+	dspmq -n -m ${MQ_QMGR_NAME} | awk -F '[()]' '{ print $4 }'
+}
+
+monitor()
+{
+	# Loop until "dspmq" says the queue manager is running
+	until [ "`state`" == "RUNNING" ]; do
+		sleep 1
+	done
+	dspmq
+
+	# Loop until "dspmq" says the queue manager is not running any more
+	until [ "`state`" != "RUNNING" ]; do
+		sleep 5
+	done
+
+	# Wait until queue manager has ended before exiting
+	while true; do
+		STATE=`state`
+		case "$STATE" in
+			ENDED*) break;;
+			*) ;;
+		esac
+		sleep 1
+	done
+	dspmq
+}
+
+mq-license-check.sh
+# If /var/mqm is empty (because it's mounted from a new host volume), then populate it
+if [ ! "$(ls -A /var/mqm)" ]; then
+	/opt/mqm/bin/amqicdir -i -f
+fi
+config
+trap stop SIGTERM SIGINT
+monitor


### PR DESCRIPTION
This pull request converts RPM files to deb so they install as native packages, added 7.5 support too

CLA comment:
I accept and agree to be bound by the terms of the IBM Contributor License Agreement