### PR TITLE
Don't run entrypoint as mqm user

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -61,7 +61,4 @@ EXPOSE 1414
 # Always put the MQ data directory in a Docker volume
 VOLUME /var/mqm
 
-# Run MQ and health-checking script as the "mqm" user
-USER mqm
-
 ENTRYPOINT ["mq.sh"]


### PR DESCRIPTION
Currently, it's possible to see the following message when you run: "AMQ6240: You must be an operating system superuser to run this command.".

We'll look into this further, but for now, we should revert to running the entrypoint as root.