### PR TITLE
Purge 32-bit libraries and tar.gz packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && ./mqlicense.sh -text_only -accept \
   # Install MQ using the RPM packages
   && rpm -ivh --force-debian $MQ_PACKAGES \
+  # Remove 32-bit libraries from 64-bit container
+  && find /opt/mqm /var/mqm -type f -exec file {} \; | awk -F: '/ELF 32-bit/{print $1}' \
+  # Remove tar.gz files unpacked by RPM postinst scripts
+  && find /opt/mqm -name '*.tar.gz' -delete \
   # Recommended: Set the default MQ installation (makes the MQ commands available on the PATH)
   && /opt/mqm/bin/setmqinst -p /opt/mqm -i \
   # Clean up all the downloaded files

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu:16.04
 LABEL maintainer "Arthur Barr <arthur.barr@uk.ibm.com>"
 
 # The URL to download the MQ installer from in tar.gz format
-ARG MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev901_linux_x86-64.tar.gz
+ARG MQ_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev901_linux_x86-64.tar.gz
 
 # The MQ packages to install
 ARG MQ_PACKAGES="MQSeriesRuntime-*.rpm MQSeriesServer-*.rpm MQSeriesMsg*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm MQSeriesWeb*.rpm"
@@ -28,6 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get install -y --no-install-recommends \
     bash \
     bc \
+    ca-certificates \
     coreutils \
     curl \
     debianutils \


### PR DESCRIPTION
Workaround a couple of packaging flaws in using the mqadv image.

- 32-bit executables and libraries don't make sense on a 64-bit image, remove them
- the GSKit and JRE rpms install and the unpack some tar.gz files, but then leave the originals behind, remove those

None of these are required by the container to operate fully. This PR reduces the image size by ~200MB

Whilst in there I also switched to using the secure TLS endpoint to download the tar.gz installer from