### PR TITLE
Don't apt-get upgrade everything, just vulnerable packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && /opt/mqm/bin/setmqinst -p /opt/mqm -i \
   # Clean up all the downloaded files
   && rm -rf /tmp/mq \
-  && apt-get update -y \
-  && apt-get upgrade -y \
+  # Apply any bug fixes not included in base Ubuntu or MQ image.
+  # Don't upgrade everything based on Docker best practices https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
+  && apt-get upgrade -y libc6 \
+  # End of bug fixes
   && rm -rf /var/lib/apt/lists/* \
   # Optional: Update the command prompt with the MQ version
   && echo "mq:$(dspmqver -b -f 2)" > /etc/debian_chroot \


### PR DESCRIPTION
[Following Docker Best practices ](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run)