### PR TITLE
Purge 32-bit libraries and tar.gz packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu:16.04
 LABEL maintainer "Arthur Barr <arthur.barr@uk.ibm.com>"
 
 # The URL to download the MQ installer from in tar.gz format
-ARG MQ_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev902_ubuntu_x86-64.tar.gz
+ARG MQ_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev902_ubuntu_x86-64.tar.gz
 
 # The MQ packages to install
 ARG MQ_PACKAGES="ibmmq-server ibmmq-java ibmmq-jre ibmmq-gskit ibmmq-web"
@@ -28,6 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get install -y --no-install-recommends \
     bash \
     bc \
+    ca-certificates \
     coreutils \
     curl \
     debianutils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     coreutils \
     curl \
     debianutils \
+    file \
     findutils \
     gawk \
     grep \
@@ -58,6 +59,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   # Install MQ using the DEB packages
   && apt-get update \
   && apt-get install -y $MQ_PACKAGES \
+  # Remove 32-bit libraries from 64-bit container
+  && find /opt/mqm /var/mqm -type f -exec file {} \; \
+    | awk -F: '/ELF 32-bit/{print $1}' | xargs --no-run-if-empty rm -f \
+  # Remove tar.gz files unpacked by RPM postinst scripts
+  && find /opt/mqm -name '*.tar.gz' -delete \
   # Recommended: Set the default MQ installation (makes the MQ commands available on the PATH)
   && /opt/mqm/bin/setmqinst -p /opt/mqm -i \
   # Clean up all the downloaded files


### PR DESCRIPTION
Workaround a couple of packaging flaws in using the mqadv image.

32-bit executables and libraries don't make sense on a 64-bit image, remove them
the GSKit and JRE rpms install and the unpack some tar.gz files, but then leave the originals behind, remove those
None of these are required by the container to operate fully. This PR reduces the image size by ~200MB

Whilst in there I also switched to using the secure TLS endpoint to download the tar.gz installer from