### PR TITLE
Add fix for login,passwd. Remove unnecessary libc6 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && rm -rf /tmp/mq \
   # Apply any bug fixes not included in base Ubuntu or MQ image.
   # Don't upgrade everything based on Docker best practices https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
-  && apt-get upgrade -y libc6 \
+  && apt-get upgrade -y login \
+  && apt-get upgrade -y passwd \
   # End of bug fixes
   && rm -rf /var/lib/apt/lists/* \
   # Optional: Update the command prompt with the MQ version


### PR DESCRIPTION
Added fixes for:

- [USN-3276-2](https://www.ubuntu.com/usn/usn-3276-2/)
- [USN-3276-1](https://www.ubuntu.com/usn/usn-3276-1/)

Removed `libc6` package upgrade as it is now included in base Ubuntu 16.04 image.