### PR TITLE
Removed requirement for `MQ_QMGR_NAME` environment variable

### DIFF
--- a/mq-create-qmgr.sh
+++ b/mq-create-qmgr.sh
@@ -16,7 +16,16 @@
 
 set -e
 
+if [ -z ${MQ_QMGR_NAME+x} ]; then
+  # no ${MQ_QMGR_NAME} supplied so set Queue Manager name as the hostname
+  # However make sure we remove any characters that are not valid.
+  echo "Hostname is: $(hostname)"
+  MQ_QMGR_NAME=`echo $(hostname) | sed 's/[^a-zA-Z0-9._%/]//g'`
+fi
+echo "Setting Queue Manager name to ${MQ_QMGR_NAME}"
+
 QMGR_EXISTS=`dspmq | grep ${MQ_QMGR_NAME} > /dev/null ; echo $?`
+
 if [ ${QMGR_EXISTS} -ne 0 ]; then
   MQ_DEV=${MQ_DEV:-"true"}
   if [ "${MQ_DEV}" == "true" ]; then

--- a/mq-monitor-qmgr.sh
+++ b/mq-monitor-qmgr.sh
@@ -16,12 +16,16 @@
 
 set -e
 
+MQ_QMGR_NAME=$1
+
 state()
 {
   dspmq -n -m ${MQ_QMGR_NAME} | awk -F '[()]' '{ print $4 }'
 }
 
-trap mq-stop-container.sh SIGTERM SIGINT
+trap "source mq-stop-container.sh" SIGTERM SIGINT
+
+echo "Monitoring Queue Manager ${MQ_QMGR_NAME}"
 
 # Loop until "dspmq" says the queue manager is running
 until [ "`state`" == "RUNNING" ]; do

--- a/mq-parameter-check.sh
+++ b/mq-parameter-check.sh
@@ -16,8 +16,6 @@
 
 set -e
 
-: ${MQ_QMGR_NAME?"ERROR: You need to set the MQ_QMGR_NAME environment variable"}
-
 # We want to do parameter checking early as then we can stop and error early before it looks
 # like everything is going to be ok (when it won't)
 if [ ! -z ${MQ_TLS_KEYSTORE+x} ]; then

--- a/mq-stop-container.sh
+++ b/mq-stop-container.sh
@@ -16,5 +16,5 @@
 
 set -e
 
-endmqm $MQ_QMGR_NAME
-which endmqweb && endmqweb
+endmqm ${MQ_QMGR_NAME}
+which endmqweb && su -c "endmqweb" -l mqm

--- a/mq.sh
+++ b/mq.sh
@@ -25,12 +25,12 @@ which strmqweb && setup-mqm-web.sh
 echo "----------------------------------------"
 mq-pre-create-setup.sh
 echo "----------------------------------------"
-mq-create-qmgr.sh
+source mq-create-qmgr.sh
 echo "----------------------------------------"
-mq-start-qmgr.sh
+source mq-start-qmgr.sh
 echo "----------------------------------------"
-mq-configure-qmgr.sh
+source mq-configure-qmgr.sh
 echo "----------------------------------------"
-mq-dev-config.sh
+source mq-dev-config.sh
 echo "----------------------------------------"
-exec mq-monitor-qmgr.sh
+exec mq-monitor-qmgr.sh ${MQ_QMGR_NAME}

--- a/test/test.js
+++ b/test/test.js
@@ -336,6 +336,6 @@ describe('MQ Docker sample', function() {
           });
         });
       });
-    }); 
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -46,23 +46,24 @@ describe('MQ Docker sample', function() {
         done();
       });
     });
-    it('should fail if MQ_QMGR_NAME is not set', function (done) {
-      exec(`docker run --rm --env LICENSE=accept  ${DOCKER_IMAGE}`, function (err, stdout, stderr) {
-        assert.equal(err.code, 1);
-        assert.isTrue(stderr.includes("ERROR"));
-        done();
-      });
-    });
   });
 
   // Utility function to run a container and wait until MQ starts
-  let runContainer = function(options) {
+  let runContainer = function(options, unsetQMName, hostname) {
     return new Promise((resolve, reject) => {
-      let cmd = `docker run -d --env LICENSE=accept --env MQ_QMGR_NAME=${QMGR_NAME} --net ${DOCKER_NETWORK} ${options} ${DOCKER_IMAGE}`;
+      let cmd = "";
+      let qmName = "";
+      if(!unsetQMName){
+        cmd = `docker run -d --env LICENSE=accept --env MQ_QMGR_NAME=${QMGR_NAME} --net ${DOCKER_NETWORK} ${options} ${DOCKER_IMAGE}`;
+        qmName=QMGR_NAME
+      } else{
+        cmd = `docker run -d --env LICENSE=accept --net ${DOCKER_NETWORK} ${options} ${DOCKER_IMAGE}`;
+        qmName=hostname
+      }
       exec(cmd, function (err, stdout, stderr) {
         if (err) reject(err);
         let containerId = stdout.trim();
-        let startStr = `IBM MQ Queue Manager ${QMGR_NAME} is now fully running`;
+        let startStr = `IBM MQ Queue Manager ${qmName} is now fully running`;
         // Run dspmq every second, until the queue manager comes up
         let timer = setInterval(function() {
           exec(`docker logs ${containerId}`, function (err, stdout, stderr) {
@@ -117,6 +118,61 @@ describe('MQ Docker sample', function() {
   describe('with running container', function() {
     let container = null;
     this.timeout(10000);
+
+    describe('and no queue manager variable supplied', function(){
+      let containerName="MQTestQM"
+
+      before(function() {
+        this.timeout(20000);
+        return runContainer("-h " + containerName, true, containerName)
+        .then((details) => {
+          container = details;
+        });
+      });
+      after(function() {
+        return deleteContainer(container.id);
+      });
+      it('should be using the hostname as the queue manager name', function (done) {
+        exec(`docker exec ${container.id} dspmq`, function (err, stdout, stderr) {
+          if (err) throw(err);
+          if (stdout && stdout.includes(containerName)) {
+            // Queue manager is up, so clear the timer
+            done();
+          }
+        });
+      });
+    });
+
+    describe('with running container', function() {
+      let container = null;
+      this.timeout(10000);
+
+      describe('and no queue manager variable supplied but the hostname has invalid characters', function(){
+        let containerName="MQ-Test-QM"
+        let containerValidName="MQTestQM"
+
+        before(function() {
+          this.timeout(20000);
+          return runContainer("-h " + containerName, true, containerValidName)
+          .then((details) => {
+            container = details;
+          });
+        });
+        after(function() {
+          return deleteContainer(container.id);
+        });
+        it('should be using the hostname as the queue manager name without the invalid characters', function (done) {
+          exec(`docker exec ${container.id} dspmq`, function (err, stdout, stderr) {
+            if (err) throw(err);
+            if (stdout && stdout.includes(containerValidName)) {
+              // Queue manager is up, so clear the timer
+              done();
+            }
+          });
+        });
+      });
+    });
+
 
     describe('and implicit volume', function() {
       before(function() {
@@ -280,6 +336,6 @@ describe('MQ Docker sample', function() {
           });
         });
       });
-    });
+    }); 
   });
 });


### PR DESCRIPTION
Removed requirement for `MQ_QMGR_NAME` environment variable
Set files so if `MQ_QMGR_NAME` is not supplied we will default to the hostname (minus invalid characters) for the Queue Manager's name.