### PR TITLE
Remove login,passwd manual update and add manual update for libgnutls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && rm -rf /tmp/mq \
   # Apply any bug fixes not included in base Ubuntu or MQ image.
   # Don't upgrade everything based on Docker best practices https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
-  && apt-get upgrade -y login \
-  && apt-get upgrade -y passwd \
+  && apt-get upgrade -y libgnutls30 \
   # End of bug fixes
   && rm -rf /var/lib/apt/lists/* \
   # Optional: Update the command prompt with the MQ version


### PR DESCRIPTION
- Remove old manual updates of login and passwd as these are no longer required.
- Add manual update of libgnutls to fix new vulnerability [USN-3318-1](https://www.ubuntu.com/usn/usn-3318-1/)
