### PR TITLE
USN-3347-1 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && rm -rf /tmp/mq \
   # Apply any bug fixes not included in base Ubuntu or MQ image.
   # Don't upgrade everything based on Docker best practices https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
-  && apt-get upgrade -y libgnutls30 \
+  && apt-get upgrade -y libgcrypt20 \
   # End of bug fixes
   && rm -rf /var/lib/apt/lists/* \
   # Optional: Update the command prompt with the MQ version


### PR DESCRIPTION
- Adds fix for [USN-3347-1 ](https://www.ubuntu.com/usn/usn-3347-1/)
- Remove unnecessary `libgnutls30` upgrade