### PR TITLE
Fix Issue 89

### DIFF
--- a/setup-mqm-web.sh
+++ b/setup-mqm-web.sh
@@ -102,39 +102,39 @@ configure_server_xml()
 
 }
 
-if [ ! -z ${MQ_DISABLE_WEB_CONSOLE+x} ]; then
-  #don't do anything
-  exit 0
-fi
+if [ -z ${MQ_DISABLE_WEB_CONSOLE+x} ]; then
+  echo "Starting MQ Console"
 
-echo "Starting MQ Console"
+  MQ_INSTALLATION=`dspmqver -b -f 512`
+  DATA_PATH=`dspmqver -b -f 4096`
+  MQ_ADMIN_NAME="admin"
+  MQ_ADMIN_PASSWORD=${MQ_ADMIN_PASSWORD:-"passw0rd"}
 
-MQ_INSTALLATION=`dspmqver -b -f 512`
-DATA_PATH=`dspmqver -b -f 4096`
-MQ_ADMIN_NAME="admin"
-MQ_ADMIN_PASSWORD=${MQ_ADMIN_PASSWORD:-"passw0rd"}
+  if [ ! -e "/tmp/webTemp" ]; then
+    mkdir -p /tmp/webTemp
+    chown mqm:mqm /tmp/webTemp
 
-if [ ! -e "/tmp/webTemp" ]; then
-  mkdir -p /tmp/webTemp
-  chown mqm:mqm /tmp/webTemp
+    configure_server_xml
+  else
+    echo "Using existing Web Server configuration."
+  fi
 
-  configure_server_xml
+  if [ ! -e "${DATA_PATH}/web/installations/${MQ_INSTALLATION}/angular.persistence/admin.json" ]; then
+    sed -i "s/<QM>/${MQ_QMGR_NAME}/g" /etc/mqm/admin.json
+    chown mqm:mqm /etc/mqm/admin.json
+    chmod 640 /etc/mqm/admin.json
+    su -c "mkdir -p ${DATA_PATH}/web/installations/${MQ_INSTALLATION}/angular.persistence" -l mqm
+    su -c "cp -PTv /etc/mqm/admin.json ${DATA_PATH}/web/installations/${MQ_INSTALLATION}/angular.persistence/admin.json" -l mqm
+  fi
+
+  #Run the server as mqm
+  su -l mqm -c "bash strmqweb &"
+  echo "MQ Console started"
+
+  # Print out the connection info
+  IPADDR="$(hostname -I | sed -e 's/[[:space:]]*$//')"
+  echo connect to \"https://$IPADDR:9443/ibmmq/console/\"
 else
-  echo "Using existing Web Server configuration."
+  # don't do anything
+  echo Skipping Web Console startup due to MQ_DISABLE_WEB_CONSOLE environment variable
 fi
-
-if [ ! -e "${DATA_PATH}/web/installations/${MQ_INSTALLATION}/angular.persistence/admin.json" ]; then
-  sed -i "s/<QM>/${MQ_QMGR_NAME}/g" /etc/mqm/admin.json
-  chown mqm:mqm /etc/mqm/admin.json
-  chmod 640 /etc/mqm/admin.json
-  su -c "mkdir -p ${DATA_PATH}/web/installations/${MQ_INSTALLATION}/angular.persistence" -l mqm
-  su -c "cp -PTv /etc/mqm/admin.json ${DATA_PATH}/web/installations/${MQ_INSTALLATION}/angular.persistence/admin.json" -l mqm
-fi
-
-#Run the server as mqm
-su -l mqm -c "bash strmqweb &"
-echo "MQ Console started"
-
-# Print out the connection info
-IPADDR="$(hostname -I | sed -e 's/[[:space:]]*$//')"
-echo connect to \"https://$IPADDR:9443/ibmmq/console/\"

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 /**
-  * © Copyright IBM Corporation 2016
+  * © Copyright IBM Corporation 2016, 2017
   *
   *
   * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test.js
+++ b/test/test.js
@@ -83,13 +83,13 @@ describe('MQ Docker sample', function() {
   };
 
   // Utility function to wait for the HTTPS web interface to become available
-  let waitForWeb = function(addr, port = 9443) {
+  let waitForWeb = function(addr, port = 9443, timeout = 60000) {
     return new Promise((resolve, reject) => {
       const INTERVAL = 3000; //ms
       let count = 0;
       let timer = setInterval(() => {
         count++;
-        if ((count * INTERVAL) >= 60000) {
+        if ((count * INTERVAL) >= timeout) {
           clearInterval(timer);
           reject(new Error(`Timed out connecting to port ${port}`));
         }
@@ -164,6 +164,36 @@ describe('MQ Docker sample', function() {
             // Queue manager is up, so clear the timer
             done();
           }
+        });
+      });
+    });
+
+    describe('with the web console disabled', function() {
+      before(function() {
+        this.timeout(20000);
+        return runContainer("--env MQ_DISABLE_WEB_CONSOLE=true")
+        .then((details) => {
+          container = details;
+        });
+      });
+      after(function() {
+        return deleteContainer(container.id);
+      });
+      it('should be listening on port 1414 on the Docker network', function (done) {
+        const client = net.connect({host: container.addr, port: 1414}, () => {
+          client.on('close', done);
+          client.end();
+        });
+      });
+      // Only run this test once, as it's quite slow
+      it('should not be listening on port 9443 on the Docker network', function (done) {
+        this.timeout(120000);
+        waitForWeb(container.addr, 9443, 30000).then(() => {
+          // We connected... so errored
+          throw new Error(`Connected to port 9443 when the console should not of been running`)
+        },(err) => {
+          //We errored which means we couldn't connect, which means the console isn't running!
+          done();
         });
       });
     });


### PR DESCRIPTION
 - Fixes Issue #89 by removing the `exit 0` from the `setup-mqm-web.sh` script and replacing it with an if else structure.

 - Adds a test for MQ_DISABLE_WEB_CONSOLE environment variable.