### PR TITLE
If the MQ license size increases anymore then we will break the buffer

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ describe('MQ Docker sample', function() {
   describe('when launching container', function () {
     this.timeout(3000);
     it('should display the license when LICENSE=view', function (done) {
-      exec(`docker run --rm --env LICENSE=view ${DOCKER_IMAGE}`, function (err, stdout, stderr) {
+      exec(`docker run --rm --env LICENSE=view ${DOCKER_IMAGE}`, {maxBuffer: 1024 * 500}, function (err, stdout, stderr) {
         assert.equal(err.code, 1);
         assert.isTrue(stdout.includes("terms"));
         done();


### PR DESCRIPTION
Currently the MQ License is about the same size as the default Javascript stdout buffer. If it was to increase anymore in future versions then this test would break.
Let's increase the buffer size to prevent this from happening in the future.